### PR TITLE
Tailwind CSSを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+
+gem "tailwindcss-rails", "~> 4.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,16 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    tailwindcss-rails (4.4.0)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.1.16)
+    tailwindcss-ruby (4.1.16-aarch64-linux-gnu)
+    tailwindcss-ruby (4.1.16-aarch64-linux-musl)
+    tailwindcss-ruby (4.1.16-arm64-darwin)
+    tailwindcss-ruby (4.1.16-x86_64-darwin)
+    tailwindcss-ruby (4.1.16-x86_64-linux-gnu)
+    tailwindcss-ruby (4.1.16-x86_64-linux-musl)
     thor (1.4.0)
     timeout (0.4.3)
     tsort (0.2.0)
@@ -334,6 +344,7 @@ DEPENDENCIES
   selenium-webdriver
   sprockets-rails
   stimulus-rails
+  tailwindcss-rails (~> 4.3)
   turbo-rails
   tzinfo-data
   web-console

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
 js: yarn build --watch
+css: bin/rails tailwindcss:watch

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
     <title><%= content_for(:title) || "Myapp" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -13,11 +13,14 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body>
-    <%= yield %>
+  <body class="bg-blue-50 text-blue-900 font-sans leading-relaxed text-base">
+    <main class="container mx-auto mt-28 px-5 flex">
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/bin/dev
+++ b/bin/dev
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-if gem list --no-installed --exact --silent foreman; then
+if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman
 fi
@@ -8,4 +8,9 @@ fi
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
-exec foreman start -f Procfile.dev --env /dev/null "$@"
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
## 概要
Tailwind CSSを導入し、アプリ全体に共通の背景色・文字色等を設定

### 内容
- `Gemfile` に `tailwindcss-rails` を追加
- `app/views/layouts/application.html.erb` に以下を設定 
  - 背景色：#EFF6FF
  - 文字色：#1E3A8A

### 関連Issue
close #6
