### PR TITLE
TailwindCSS再導入と全画面中央表示レイアウト追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,8 +20,10 @@
 
   <body class="bg-blue-50 text-blue-900 font-sans leading-relaxed text-base">
     <%= render 'shared/header' %>
-    <main class="container mx-auto mt-28 px-5 flex">
-      <%= yield %>
+    <main class="min-h-screen flex items-center justify-center">
+      <div class="w-full max-w-md bg-white p-8 rounded-lg shadow-lg">
+        <%= yield %>
+      </div>
     </main>
   </body>
 </html>


### PR DESCRIPTION
## 概要
TailwindCSSを再導入し、全ページで中央ボックス表示が可能な共通レイアウトを作成

### 変更内容
- app/assets/stylesheets/application.tailwind.css の作成
- app/views/layouts/application.html.erb の main タグ内に中央表示レイアウト追加

### 関連Issue
#6