### PR TITLE
Cloudinary導入とActiveStorage画像アップロード対応、UUID移行に伴うrecord_id不整合を修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  gem "dotenv-rails"
 end
 
 group :development do
@@ -63,3 +65,7 @@ gem "devise", "~> 4.9"
 gem "ransack"
 
 gem "kaminari"
+
+gem "cloudinary"
+
+gem "activestorage-cloudinary-service"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       activerecord (= 7.2.3)
       activesupport (= 7.2.3)
       marcel (~> 1.0)
+    activestorage-cloudinary-service (0.2.3)
     activesupport (7.2.3)
       base64
       benchmark (>= 0.3)
@@ -97,6 +98,11 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cgi (0.5.0)
+    cloudinary (2.4.4)
+      faraday (>= 2.0.1, < 3.0.0)
+      faraday-follow_redirects (~> 0.5)
+      faraday-multipart (~> 1.0, >= 1.0.4)
+      ostruct
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crass (1.0.6)
@@ -110,9 +116,23 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (3.2.0)
+    dotenv-rails (3.2.0)
+      dotenv (= 3.2.0)
+      railties (>= 6.1)
     drb (2.2.3)
     erb (5.1.3)
     erubi (1.13.1)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
@@ -170,6 +190,9 @@ GEM
     mini_mime (1.1.5)
     minitest (5.26.0)
     msgpack (1.8.0)
+    multipart-post (2.4.1)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.5.12)
       date
       net-protocol
@@ -197,6 +220,7 @@ GEM
     nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.0)
       ast (~> 2.4.1)
@@ -347,6 +371,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
+    uri (1.1.1)
     useragent (0.16.11)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -376,11 +401,14 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  activestorage-cloudinary-service
   bootsnap
   brakeman
   capybara
+  cloudinary
   debug
   devise (~> 4.9)
+  dotenv-rails
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -86,15 +86,12 @@
     <%= f.label :taste_tags, "タグ", class: "w-32 font-semibold" %>
     <%= f.text_field :taste_tags, class: "flex-1 border border-gray-300 rounded-lg p-2 focus:ring focus:ring-blue-200" %>
   </div>
-  
-  <!-- 一時的にコメントアウト -->
-  <!--
+
   <div class="flex items-center mb-6">
     <%= f.label :label_image, "ラベル画像", class: "w-32 font-semibold" %>
     <%= f.file_field :label_image, class: "flex-1" %>
   </div>
-  -->
-  
+
   <div class="flex items-center mb-4">
     <%= f.label :comment, "メモ", class: "w-32 font-semibold" %>
     <%= f.text_area :comment, class: "flex-1 border border-gray-300 rounded-lg p-2 focus:ring focus:ring-blue-200" %>

--- a/app/views/sakes/_sake_card.html.erb
+++ b/app/views/sakes/_sake_card.html.erb
@@ -5,8 +5,8 @@
         <div class="aspect-square bg-gray-100 rounded-lg 
                     flex items-center justify-center overflow-hidden">
           <% if sake.label_image.attached? %>
-            <%= image_tag sake.label_image,
-                  class: "max-h-40 object-contain" %>
+            <%= image_tag url_for(sake.label_image),
+                  class: "w-full aspect-square object-cover rounded-lg" %>
           <% else %>
             <span class="text-gray-400 text-sm">no label</span>
           <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -32,3 +32,9 @@ local:
 #   service: Mirror
 #   primary: local
 #   mirrors: [ amazon, google, microsoft ]
+
+cloudinary:
+  service: Cloudinary
+  cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
+  api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
+  api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>

--- a/db/migrate/20260408065130_change_active_storage_record_id_to_uuid.rb
+++ b/db/migrate/20260408065130_change_active_storage_record_id_to_uuid.rb
@@ -1,0 +1,9 @@
+class ChangeActiveStorageRecordIdToUuid < ActiveRecord::Migration[7.2]
+  def change
+    add_column :active_storage_attachments, :record_id_tmp, :uuid
+
+    remove_column :active_storage_attachments, :record_id
+
+    rename_column :active_storage_attachments, :record_id_tmp, :record_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_19_065316) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_08_065130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -18,11 +18,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_19_065316) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.uuid "record_id"
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|


### PR DESCRIPTION
## 概要
Cloudinaryを導入し、ActiveStorageで画像アップロードができるように対応
あわせて、主キーをUUIDに変更したことによるActiveStorageの不整合を修正

## 内容
- Cloudinaryを導入し、画像の外部ストレージ保存に対応
- 日本酒（Sake）に画像（label_image）をアップロードできるよう実装
- active_storage_attachments.record_id をUUID型へ変更

## 関連Issue
Closes #24