### PR TITLE
user_badgesのuser_id重複インデックスを削除

### DIFF
--- a/db/migrate/20260416065454_create_user_badges.rb
+++ b/db/migrate/20260416065454_create_user_badges.rb
@@ -8,6 +8,5 @@ class CreateUserBadges < ActiveRecord::Migration[7.2]
     end
 
     add_index :user_badges, [ :user_id, :badge_id ], unique: true
-    add_index :user_badges, :user_id
   end
 end


### PR DESCRIPTION
## 概要
user_badgesテーブル作成時にuser_idのインデックスが重複定義されていたため、
Renderデプロイ時にエラーが発生していた問題を修正

## 内容
- 不要な add_index :user_badges, :user_id を削除