### PR TITLE
バッジの初期seedデータを追加

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,3 +12,14 @@ prefectures = %w[
 prefectures.each do |name|
   Prefecture.find_or_create_by!(name: name)
 end
+
+badges = [
+  { name: "はじめて", condition_type: "sake_count", condition_value: 1, position: 1 },
+  { name: "ビギナー", condition_type: "sake_count", condition_value: 5, position: 2 },
+  { name: "日本酒好き", condition_type: "sake_count", condition_value: 10, position: 3 }
+]
+
+badges.each do |attrs|
+  badge = Badge.find_or_initialize_by(name: attrs[:name])
+  badge.update!(attrs)
+end


### PR DESCRIPTION
## 概要
バッジ機能の初期データとして、badgeテーブルにseedデータを追加

## 内容
- seed.rbにバッジデータを追加
  - 日本酒登録本数に応じたバッジ(はじめて：1本・ビギナー：5本・日本酒好き：10本)
- find_or_initialize_by + update! を使用し、既存データがある場合も最新状態に更新されるように実装 